### PR TITLE
docs: reconcile README and docs with the New Architecture migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > ⚠️ **WARNING: This library is currently in active development and is NOT ready for production use.**
 >
-> - **This library still targets the legacy React Native architecture.** React Native 0.82
->   removed the ability to opt out of the New Architecture and 0.83 removed the legacy code
->   entirely, so on current React Native this works only through the deprecated interop layer.
->   A Fabric/TurboModule migration is the next planned change — see [`docs/ROADMAP.md`](docs/ROADMAP.md)
+> - **The New Architecture (Fabric / TurboModules) migration has landed.** The library now ships
+>   codegen specs, Fabric component views, and TurboModules, and the example app builds green on
+>   iOS and Android in CI. It has **not yet been verified on a physical device** — see
+>   [`docs/ROADMAP.md`](docs/ROADMAP.md)
 > - The implementation is incomplete and may contain bugs
 > - API changes are likely to occur
 > - Some features may not work as expected
@@ -21,7 +21,7 @@ AR object capture session for React Native using Apple's Object Capture API. Thi
 
 - iOS 17.0 or later
 - iPhone 12 Pro or newer (devices with LiDAR sensor)
-- React Native 0.76.0 or later
+- React Native 0.76.0 or later with the New Architecture (Fabric / TurboModules) enabled
 
 ## Installation
 1. Install library
@@ -59,7 +59,7 @@ The main component for capturing 3D objects. It provides a camera interface with
 | `onScanPassCompleted` | (evt: `NativeSyntheticEvent<ScanPassCompleted>`) => void | No | Callback fired when a scan pass is completed. It is recommended to complete 3 scan pass' before finishing the object capture session |
 | `onSessionStateChange` | (evt: `NativeSyntheticEvent<SessionStateChange>`) => void | No | Callback fired when the capture session state changes |
 | `onTrackingStateChange` | (evt: `NativeSyntheticEvent<TrackingStateChange>`) => void | No | Callback fired when the tracking state changes |
-| `onFeedbackStateChange` | (evt: `NativeSyntheticEvent<TrackingStateChange>`) => void | No | Callback fired when the feedback state changes |
+| `onFeedbackStateChange` | (evt: `NativeSyntheticEvent<FeedbackStateChange>`) => void | No | Callback fired when the feedback state changes |
 | `onError` | (evt: `NativeSyntheticEvent<SessionError>`) => void | No | Callback fired when an error occurs during capture |
 
 #### Methods
@@ -75,13 +75,29 @@ The main component for capturing 3D objects. It provides a camera interface with
 | `beginNewScan` | When called this method will begin a new scan for the Object Capture Session |
 | `finishSession` | Ends the capture session and finalises the captured images, so they can be handed to a `PhotogrammetrySession`. Call this once all scan passes are complete |
 | `cancelSession` | Call this method when cleaning up and tearing down the Object Capture Session |
-| `isDeviceSupported` | Resumes boolean value indicating if the device supports AR and LiDAR |
+| `isDeviceSupported` | Returns a boolean value indicating if the device supports AR and LiDAR |
 | `getSessionState` | Returns the current SessionState |
 | `getTrackingState` | Returns the current TrackingState |
 | `getFeedbackState` | Returns the current FeedbackState |
 | `getNumberOfShotsTaken` | Returns integer count of images taken for current Object Capture Session |
 | `getUserCompletedScanState` | Returns boolean if the current scan pass is completed |
 | `getNumberOfScanPassUpdates` | Returns the number of scan pass' completed |
+
+> **Prefer the `ObjectCaptureSession` module over the ref.** The native session is a singleton,
+> so these calls were never scoped to a view instance. The same methods are exported as a
+> standalone module you can call from anywhere, without holding a ref:
+>
+> ```jsx
+> import { ObjectCaptureSession } from 'react-native-object-capture';
+>
+> await ObjectCaptureSession.startDetection();
+> await ObjectCaptureSession.startCapturing();
+> const state = await ObjectCaptureSession.getSessionState();
+> ```
+>
+> The `ObjectCaptureView` ref is retained as a thin delegate for backwards compatibility and may
+> be deprecated. The package also exports `ObjectCaptureConstants` (native enum/string constants)
+> and every type referenced above.
 
 #### Example
 
@@ -394,7 +410,7 @@ Handles the processing of captured images into a 3D model. This component manage
 | `imagesDirectory` | String | Yes | Directory containing the captured images, relative to the documents directory |
 | `checkpointDirectory` | String | Yes | Directory used for reconstruction checkpoints |
 | `outputPath` | String | Yes | Where to write the model, relative to the documents directory. Accepts a bare filename (`'model.usdz'`) or any nesting depth (`'Outputs/chair/model.usdz'`). Must include a file extension |
-| `detail` | `'preview' \| 'reduced' \| 'medium' \| 'full' \| 'raw'` | No | Reconstruction quality. Higher levels take substantially longer and produce larger files. Defaults to the framework's own default. Not every level is available on every device — an unsupported level surfaces via `addErrorListener` |
+| `detail` | `'reduced'` | No | Reconstruction quality. On iOS, `'reduced'` is the only level `PhotogrammetrySession.Request.Detail` exposes (the other levels — `preview`/`medium`/`full`/`raw` — are macOS only). Omit to use the framework's own default; passing an unsupported level rejects the promise with `DETAIL_ERROR` |
 
 #### Dimensions
 

--- a/docs/NATIVE_MIGRATION_PLAN.md
+++ b/docs/NATIVE_MIGRATION_PLAN.md
@@ -1,11 +1,19 @@
 # Native New Architecture Migration — Step-by-Step
 
-The JS and codegen layer is done (see the Phase 1 section of `ROADMAP.md`). This is the
-remaining native work: turning three `RCTViewManager` classes into Fabric component views, and
+> **Status: implemented.** This migration has landed on `main` (merged in
+> [#10](https://github.com/tristanheilman/react-native-object-capture/pull/10)). The three views
+> are now Fabric component views (`*ComponentView.mm` + `*FabricContainer.swift`) and the modules
+> are TurboModules; the example app compiles green on iOS and Android in CI. This document is kept
+> as the design record and a guide for the still-pending pieces (the RN version bump and on-device
+> verification). **The code in the repo is the source of truth** — the snippets below are the
+> shape it was built to, not necessarily line-for-line what shipped.
+
+The JS and codegen layer was done first (see the Phase 1 section of `ROADMAP.md`). This document
+covers the native work: turning three `RCTViewManager` classes into Fabric component views, and
 deciding what to do about the modules.
 
-Written against the codegen contracts as of RN 0.82/0.83. **None of the Swift or ObjC++ in this
-repo has been compiled** — treat every snippet here as a shape to follow, not code to paste.
+Originally written against the codegen contracts as of RN 0.82/0.83, then implemented against
+RN 0.79.2 (the example's current version).
 
 ---
 

--- a/docs/PRODUCT_ASSESSMENT.md
+++ b/docs/PRODUCT_ASSESSMENT.md
@@ -4,6 +4,12 @@ An honest read on what `react-native-object-capture` currently is, what the orig
 "will my furniture fit in this apartment" idea would actually require, what the market
 looks like now that generative 3D has landed, and where (if anywhere) the money is.
 
+> **Update (post-assessment):** the top engineering recommendation below — migrating to the New
+> Architecture (§2.1, §5) — has since shipped. The library now uses Fabric component views and
+> TurboModules, and the example builds green on iOS and Android in CI (device verification still
+> pending). See [`ROADMAP.md`](ROADMAP.md) for current status. The market analysis is unchanged
+> and preserved as written.
+
 ---
 
 ## 1. What we actually have today

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,7 +3,10 @@
 Consolidates `PRODUCT_ASSESSMENT.md` (what we have, what the market looks like) and
 `ALTERNATIVE_DIRECTIONS.md` (where else this could go) into decisions and an ordered plan.
 
-**Status:** July 2026. Library dormant since June 2025, resuming work.
+**Status:** July 2026. Library dormant since June 2025, resumed work. Phase 0 (correctness and
+capability) and Phase 1 (New Architecture migration) have landed on `main` — the example app now
+builds green on iOS and Android in CI. Still outstanding before Phase 1 is truly done: bumping the
+example off `react-native@0.79.2` and verifying on a physical LiDAR device.
 
 ---
 
@@ -102,22 +105,20 @@ If this ships, it ships gated to the categories that work, with the others expli
 
 ## Ordered plan
 
-### Phase 0 — Correctness and capability *(current)*
+### Phase 0 — Correctness and capability *(complete)*
 
 Contained changes, verifiable with typecheck/lint/tests, no architecture churn.
 
-- [ ] Fix `outputPath` parsing bug — `RNPhotogrammetrySession.swift:54-57` splits on `/` and
-      hard-indexes `[0]`/`[1]`; flat paths crash on out-of-range, nested paths write elsewhere
-- [ ] Expose `PhotogrammetrySession.Configuration.detail` (`reduced`/`medium`/`full`/`raw`) —
-      currently every caller pays for maximum quality
-- [ ] **Surface real-world dimensions** — add `.bounds` to the request list and bridge the
-      `ObjectCaptureSession` bounding box so JS gets `{width, height, depth}` in metres.
-      *This is the single highest-value change in the repo.* Object Capture already knows the
-      extent; we throw it away. Without it, D4 is not true of our own library.
-- [ ] Document `finishSession` — implemented end-to-end, used by the example, missing from the
-      README methods table
+- [x] Fix `outputPath` parsing bug — resolved `outputPath` at any nesting depth (flat filenames
+      and nested paths both write to the right place)
+- [x] Expose `PhotogrammetrySession.Request.detail` — note only `reduced` is available on iOS;
+      `preview`/`medium`/`full`/`raw` are macOS only, so the JS type is `'reduced'`
+- [x] **Surface real-world dimensions** — added `.bounds` to the request list and bridged the
+      bounding box, so JS gets `{width, height, depth, center}` in metres via `onDimensions`.
+      *The single highest-value change in the repo.*
+- [x] Document `finishSession` — now in the README methods table
 
-### Phase 1 — New Architecture migration *(in progress)*
+### Phase 1 — New Architecture migration *(complete — merged in [#10](https://github.com/tristanheilman/react-native-object-capture/pull/10))*
 
 Required before anyone can use this on a current React Native. RN 0.82 removed the legacy
 opt-out; 0.83 removed the legacy code. The interop layer is not a way out: view commands and
@@ -140,15 +141,17 @@ and this library depends on both.
 - [x] Podspec: removed the hard dependency on `React-Codegen`, renamed to `ReactCodegen` in
       RN 0.75, which would fail to resolve on any current version.
 
-**Remaining — native layer.** Step-by-step guide in [`NATIVE_MIGRATION_PLAN.md`](NATIVE_MIGRATION_PLAN.md):
+**Native layer.** Step-by-step guide in [`NATIVE_MIGRATION_PLAN.md`](NATIVE_MIGRATION_PLAN.md):
 
-- [ ] `RCTViewComponentView` subclasses for the three views, replacing the `RCTViewManager`
-      classes, with the SwiftUI hosting controllers reparented onto them
-- [ ] Component descriptors + `RCT_EXPORT_VIEW_COMPONENT` registration
-- [ ] TurboModule conformance for `RNObjectCaptureSession`, `RNPhotogrammetrySession` and
-      `RNObjectCapture` (Swift needs an ObjC++ shim to vend `getTurboModule:`)
+- [x] `RCTViewComponentView` subclasses for the three views, replacing the `RCTViewManager`
+      classes, with the SwiftUI hosting controllers reparented onto them (the
+      `*ComponentView.mm` + `*FabricContainer.swift` pairs)
+- [x] Component descriptors + component registration via `codegenConfig.ios.componentProvider`
+- [x] TurboModule conformance for `RNObjectCaptureSession`, `RNPhotogrammetrySession` and
+      `RNObjectCapture`
 - [ ] Bump the example app off `react-native@0.79.2`
-- [ ] **Verify on device.** Everything in Phase 0 and 1 has been written without a compiler.
+- [ ] **Verify on device.** The native code now compiles green in CI (iOS + Android), but has
+      not been run on a physical LiDAR device.
 
 ### Phase 2 — Product surface
 
@@ -170,7 +173,8 @@ and this library depends on both.
 
 ## Known constraint on this work
 
-Phases 0 and 1 touch Swift that **cannot be compiled or run in the current environment** — no
-Xcode, no device. TypeScript, lint, and Jest are verifiable here; the native side is written
-against the Apple API surface and must be built and tested on a LiDAR device before release.
-Nothing in Phase 0 or 1 should be considered done until that happens.
+The native side of Phases 0 and 1 now **compiles in CI** (iOS via Xcode on `macos-latest`,
+Android via Gradle), so the code is no longer written blind against the Apple API surface. What
+remains unverified is **runtime behaviour on a physical LiDAR device** — a green build is not a
+working capture session. Phase 0 and 1 are not fully done until an on-device pass confirms the
+capture → photogrammetry → QuickLook flow end to end.


### PR DESCRIPTION
## Summary

Now that the New Architecture (Fabric/TurboModules) migration has merged (#10), this brings the docs back in line with the code. All changes verified against the actual public API in `src/`.

### README.md
- **Warning banner**: no longer says the migration is "the next planned change" — it has landed (Fabric component views + TurboModules, green iOS/Android CI). Flags that on-device verification is still pending.
- **Requirements**: note the New Architecture is required.
- **`detail` option**: corrected from `'preview' | 'reduced' | 'medium' | 'full' | 'raw'` to **`'reduced'`** — the only level `PhotogrammetrySession.Request.Detail` exposes on iOS (matches `PhotogrammetryDetail` in `src/modules/PhotogrammetrySession.ts`). Notes the others are macOS-only and that an unsupported level rejects with `DETAIL_ERROR`.
- **Bug fix**: `onFeedbackStateChange` payload was typed as `TrackingStateChange` → `FeedbackStateChange`.
- **Typo**: `isDeviceSupported` "Resumes boolean value" → "Returns".
- **New docs**: the `ObjectCaptureSession` imperative module (now the preferred API over the view ref) and the `ObjectCaptureConstants` export.

### docs/ROADMAP.md
- Phase 0 items checked off (outputPath fix, detail level, dimensions, finishSession).
- Phase 1 marked **complete (merged in #10)** — native items checked, with the RN version bump and on-device verification left open.
- Refreshed the status header and the now-outdated "cannot be compiled in this environment" constraint note (CI compiles it now).

### docs/NATIVE_MIGRATION_PLAN.md
- Added an **"implemented"** banner pointing at the code as the source of truth.

### docs/PRODUCT_ASSESSMENT.md
- Added a dated note that the recommended migration shipped; left the market analysis intact as a point-in-time record.

Left untouched (no code-tied inaccuracies): `ALTERNATIVE_DIRECTIONS.md`, `CONTRIBUTING.md`, `SECURITY.md`, `example/README.md`.

## Test plan
Docs-only change — no code touched. CI lint/test/build should pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)