### PR TITLE
chore: set real peerDependencies floors

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-native": "*"
+    "react": ">=18.2.0",
+    "react-native": ">=0.79.0"
   },
   "workspaces": [
     "example"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9528,8 +9528,8 @@ __metadata:
     turbo: ^1.10.7
     typescript: ^5.8.3
   peerDependencies:
-    react: "*"
-    react-native: "*"
+    react: ">=18.2.0"
+    react-native: ">=0.79.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

The library is **New-Architecture-only** (Fabric component views + TurboModules) and has only ever been validated on React Native 0.79+. The `"*"` peer ranges advertised support all the way back to RN 0.60 / legacy arch — which is false and drops anyone on an older RN straight into a broken build.

- `react-native`: `"*"` → `">=0.79.0"`
- `react`: `"*"` → `">=18.2.0"`

Open-ended floors (no upper bound) so future RN releases keep resolving. New Arch being *required* is already documented in the README.

## Test plan
- [x] commitlint passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)