### PR TITLE
chore: clean up release tag/title format (vX.Y.Z)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## Summary

release-please defaults `include-component-in-tag` to **true**, which is why the last release landed as tag `react-native-object-capture-v0.2.4` and title **"react-native-object-capture: v0.2.4"** — inconsistent with the earlier release-it tags (`v0.2.3`, …) and long in the release list.

Setting `include-component-in-tag: false` makes future releases tag and title as plain **`vX.Y.Z`** (the `v` prefix is retained via the `include-v-in-tag` default).

## Effect
- **Next release** → tag `v0.2.5`, title `v0.2.5`
- Takes effect on the next `feat:`/`fix:` release (chores like this one don't cut a release)
- The existing `v0.2.4` release/tag is left as-is — retagging a published release would break its npm provenance link; only its **title** is tidied separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)