### PR TITLE
feat: expose overCaptureEnabled on ObjectCaptureView

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The main component for capturing 3D objects. It provides a camera interface with
 | `style` | ViewStyle | Yes | Style object for the cloud point view container |
 | `checkpointDirectory` | String | Yes | Directory to use for the object capture session |
 | `imagesDirectory` | String | Yes | Directory to use to save image captures during object capture session |
+| `overCaptureEnabled` | Boolean | No | When `true`, captures extra images beyond the guided passes so the same folder can later be reprocessed at higher detail on macOS (maps to `ObjectCaptureSession.Configuration.isOverCaptureEnabled`). Defaults to `false`. |
 | `onCaptureComplete` | (evt: `NativeSyntheticEvent<CaptureComplete>`) => void | No | Callback fired when object capture is complete |
 | `onScanPassCompleted` | (evt: `NativeSyntheticEvent<ScanPassCompleted>`) => void | No | Callback fired when a scan pass is completed. It is recommended to complete 3 scan pass' before finishing the object capture session |
 | `onSessionStateChange` | (evt: `NativeSyntheticEvent<SessionStateChange>`) => void | No | Callback fired when the capture session state changes |

--- a/ios/RNObjectCaptureContainers.h
+++ b/ios/RNObjectCaptureContainers.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)registerOnError:(void (^)(NSString *error))block;
 - (void)setCheckpointDirectory:(NSString *)directory;
 - (void)setImagesDirectory:(NSString *)directory;
+- (void)setOverCaptureEnabled:(BOOL)enabled;
 @end
 
 @interface RNObjectCapturePointCloudViewFabricContainer : UIView

--- a/ios/Session/RNObjectCaptureSessionManager.swift
+++ b/ios/Session/RNObjectCaptureSessionManager.swift
@@ -28,6 +28,8 @@ class RNObjectCaptureSessionManager: NSObject, ObservableObject {
     private var checkpointDirectory: String = "Snapshots/"
     // Images directory file path
     private var imagesDirectory: String = "Images/"
+    // Whether to capture extra images for higher-detail reprocessing on macOS
+    private var overCaptureEnabled: Bool = false
     // Fabric callbacks for ObjectCaptureView events
     var fabricCaptureOnSessionStateChange: ((String) -> Void)?
     var fabricCaptureOnTrackingStateChange: ((String) -> Void)?
@@ -67,6 +69,10 @@ class RNObjectCaptureSessionManager: NSObject, ObservableObject {
 
     func setImagesDirectory(_ directory: String) {
         self.imagesDirectory = directory
+    }
+
+    func setOverCaptureEnabled(_ enabled: Bool) {
+        self.overCaptureEnabled = enabled
     }
 
     func sendEvent(name: String, body: [String: Any]) {
@@ -220,6 +226,7 @@ class RNObjectCaptureSessionManager: NSObject, ObservableObject {
         
         var config = ObjectCaptureSession.Configuration()
         config.checkpointDirectory = self.getCheckpointDirectory()
+        config.isOverCaptureEnabled = self.overCaptureEnabled
 
         // Create directories if they don't exist
         let appendedImagesDirectory = self.getImagesDirectory()

--- a/ios/View/RNObjectCaptureView/RNObjectCaptureView.swift
+++ b/ios/View/RNObjectCaptureView/RNObjectCaptureView.swift
@@ -121,7 +121,13 @@ class RNObjectCaptureView: RCTViewManager {
     func setImagesDirectory(_ imagesDirectory: String) {
         _sharedSessionManager.setImagesDirectory(imagesDirectory)
     }
-    
+
+    // Setter method for over-capture (extra images for higher-detail reprocessing)
+    @objc
+    func setOverCaptureEnabled(_ overCaptureEnabled: Bool) {
+        _sharedSessionManager.setOverCaptureEnabled(overCaptureEnabled)
+    }
+
 
     // Will resume the object capture session
     @objc
@@ -445,6 +451,13 @@ class RNObjectCaptureViewContainer: UIView {
     func setImagesDirectory(_ imagesDirectory: String) {
         if let viewManager = self.findViewManager() {
             viewManager.setImagesDirectory(imagesDirectory)
+        }
+    }
+
+    @objc
+    func setOverCaptureEnabled(_ overCaptureEnabled: Bool) {
+        if let viewManager = self.findViewManager() {
+            viewManager.setOverCaptureEnabled(overCaptureEnabled)
         }
     }
 

--- a/ios/View/RNObjectCaptureView/RNObjectCaptureViewBridge.m
+++ b/ios/View/RNObjectCaptureView/RNObjectCaptureViewBridge.m
@@ -75,5 +75,6 @@ RCT_EXPORT_VIEW_PROPERTY(onSessionStateChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onError, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(checkpointDirectory, NSString)
 RCT_EXPORT_VIEW_PROPERTY(imagesDirectory, NSString)
+RCT_EXPORT_VIEW_PROPERTY(overCaptureEnabled, BOOL)
 
 @end

--- a/ios/View/RNObjectCaptureView/RNObjectCaptureViewComponentView.mm
+++ b/ios/View/RNObjectCaptureView/RNObjectCaptureViewComponentView.mm
@@ -91,6 +91,7 @@ using namespace facebook::react;
     const auto &newProps = *std::static_pointer_cast<const RNObjectCaptureViewProps>(props);
     [_fabricContainer setCheckpointDirectory:[NSString stringWithUTF8String:newProps.checkpointDirectory.c_str()]];
     [_fabricContainer setImagesDirectory:[NSString stringWithUTF8String:newProps.imagesDirectory.c_str()]];
+    [_fabricContainer setOverCaptureEnabled:newProps.overCaptureEnabled];
     [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/View/RNObjectCaptureView/RNObjectCaptureViewFabricContainer.swift
+++ b/ios/View/RNObjectCaptureView/RNObjectCaptureViewFabricContainer.swift
@@ -101,6 +101,9 @@ import UIKit
     @objc func setImagesDirectory(_ directory: String) {
         sessionManager.setImagesDirectory(directory)
     }
+    @objc func setOverCaptureEnabled(_ enabled: Bool) {
+        sessionManager.setOverCaptureEnabled(enabled)
+    }
 
     deinit {
         sessionManager.fabricCaptureOnSessionStateChange = nil

--- a/src/__tests__/RNObjectCaptureView.test.tsx
+++ b/src/__tests__/RNObjectCaptureView.test.tsx
@@ -15,6 +15,19 @@ describe('RNObjectCaptureView', () => {
     expect(getByTestId('RNObjectCaptureView')).toBeTruthy();
   });
 
+  it('forwards overCaptureEnabled to the native component', () => {
+    const { getByTestId } = render(
+      <ObjectCaptureView
+        checkpointDirectory="test"
+        imagesDirectory="test"
+        overCaptureEnabled
+      />
+    );
+    expect(getByTestId('RNObjectCaptureView').props.overCaptureEnabled).toBe(
+      true
+    );
+  });
+
   describe('event handlers', () => {
     it('calls onSessionStateChange when session state changes', () => {
       const onSessionStateChange = jest.fn();

--- a/src/components/RNObjectCaptureView.tsx
+++ b/src/components/RNObjectCaptureView.tsx
@@ -36,6 +36,12 @@ export interface ObjectCaptureViewProps {
   testID?: string;
   checkpointDirectory: string;
   imagesDirectory: string;
+  /**
+   * When true, the session captures extra images beyond the guided passes so
+   * the same folder can later be reprocessed at higher detail on macOS. Maps to
+   * `ObjectCaptureSession.Configuration.isOverCaptureEnabled`. Defaults to false.
+   */
+  overCaptureEnabled?: boolean;
   onSessionStateChange?: (
     event: NativeSyntheticEvent<SessionStateChange>
   ) => void;
@@ -88,6 +94,7 @@ const ObjectCaptureView = forwardRef<
       testID = 'RNObjectCaptureView',
       checkpointDirectory,
       imagesDirectory,
+      overCaptureEnabled,
       onSessionStateChange,
       onTrackingStateChange,
       onFeedbackStateChange,
@@ -110,6 +117,7 @@ const ObjectCaptureView = forwardRef<
         testID={testID}
         checkpointDirectory={checkpointDirectory}
         imagesDirectory={imagesDirectory}
+        overCaptureEnabled={overCaptureEnabled}
         onCaptureComplete={asNativeHandler(onCaptureComplete)}
         onFeedbackStateChange={asNativeHandler(onFeedbackStateChange)}
         onTrackingStateChange={asNativeHandler(onTrackingStateChange)}

--- a/src/specs/RNObjectCaptureViewNativeComponent.ts
+++ b/src/specs/RNObjectCaptureViewNativeComponent.ts
@@ -43,6 +43,7 @@ export type SessionErrorEvent = {
 export interface NativeProps extends ViewProps {
   checkpointDirectory?: string;
   imagesDirectory?: string;
+  overCaptureEnabled?: boolean;
   onSessionStateChange?: DirectEventHandler<SessionStateChangeEvent>;
   onTrackingStateChange?: DirectEventHandler<TrackingStateChangeEvent>;
   onFeedbackStateChange?: DirectEventHandler<FeedbackStateChangeEvent>;


### PR DESCRIPTION
## Summary

Surfaces `ObjectCaptureSession.Configuration.isOverCaptureEnabled` (iOS 17+) as an **`overCaptureEnabled`** boolean prop on `ObjectCaptureView`. When `true`, the session captures extra images beyond the guided passes so the same capture folder can later be reprocessed at **higher detail on macOS**. Defaults to `false` (Apple's default).

This is the one real gap surfaced by the iOS 26 Object Capture SDK diff — the on-device detail levels are unchanged (still `.reduced`-only on iOS), but this capture-time config flag wasn't exposed.

## Wiring
Mirrors the existing `checkpointDirectory` path exactly:
- codegen spec + public wrapper prop (`src/specs`, `src/components`)
- Fabric: `ComponentView.mm` → `FabricContainer.swift` → session manager
- legacy `RCTViewManager` parity (`Bridge.m` + `RNObjectCaptureView.swift`)
- manager applies `config.isOverCaptureEnabled` when building the session

## Validation (local)
- ✅ `yarn typecheck`
- ✅ jest — new test asserts the prop forwards to the native component
- ✅ `yarn lint` (0 errors)
- ✅ `pod install` — codegen emits `bool overCaptureEnabled{false}` (matches the `ComponentView.mm` usage + Apple's default)
- ✅ full iOS simulator build: **BUILD SUCCEEDED**

## Note
The **runtime** effect (extra frames captured, higher-detail macOS reprocessing) needs a LiDAR device to observe — it folds into the pending on-device §7 checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)