### PR TITLE
chore(android): refresh stale SDK fallbacks and correct the doc claim about them

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 ObjectCapture_kotlinVersion=2.0.21
 ObjectCapture_minSdkVersion=24
-ObjectCapture_targetSdkVersion=34
-ObjectCapture_compileSdkVersion=35
+ObjectCapture_targetSdkVersion=36
+ObjectCapture_compileSdkVersion=36
 ObjectCapture_ndkVersion=27.1.12297006

--- a/docs/android/CURRENT_STATE.md
+++ b/docs/android/CURRENT_STATE.md
@@ -99,5 +99,12 @@ kotlinVersion=2.0.21    ndkVersion=27.1.12297006
 `minSdk 24` matches the ARCore floor (Android 7.0), which is convenient but coincidental — nothing
 here depends on ARCore and there is no `com.google.ar:core` dependency.
 
-`targetSdkVersion 34` is behind the Play Store's requirement for new submissions and worth bumping
-regardless of what happens with Android support. **Still outstanding.**
+These are **fallback defaults, not values imposed on consumers**. `android/build.gradle` reads them
+through `getExtOrIntegerDefault`, which prefers `rootProject.ext` and only falls back to
+`gradle.properties`. Any React Native app from a current template defines `ext.targetSdkVersion` at
+the root, so the library compiles against the app's value — the example app here builds this module
+at 36, not 34.
+
+So `targetSdkVersion 34` is worth refreshing for tidiness and for anyone consuming the module
+without root ext values, but it does not hold an app back from the Play Store's requirement for
+new submissions. **Still outstanding, low priority.**


### PR DESCRIPTION
Follow-up to #25, clearing the last item it left open — and fixing something #25 got wrong.

## The correction

`docs/android/CURRENT_STATE.md` called `targetSdkVersion 34` a Play Store blocker. **It isn't.**

`android/build.gradle` reads these through `getExtOrIntegerDefault`, which prefers `rootProject.ext` and only falls back to `gradle.properties`. Every current React Native template defines `ext.targetSdkVersion` at the root, so the library compiles against the *app's* value — the example app in this repo builds this module at 36, not 34.

As written, a reader could have concluded the library was holding their app back from Play Store submission. The doc now explains the fallback mechanism and marks the item low priority.

## The bump

`targetSdkVersion` 34 → 36, `compileSdkVersion` 35 → 36.

Worth noting these aren't a leap into the untested: since `ext` wins, the module has **already been compiling against 36 all along** in the example build, which is the path CI exercises. This aligns the fallback with the configuration already known to work, for consumers who don't set root ext values.

`kotlinVersion 2.0.21` is stale the same way (the example pins 2.1.20). Left alone to keep this to one concern.

## Verification

Example Android build green. No JS/TS touched, so typecheck and tests are unaffected by this diff.
